### PR TITLE
Fixed configuration of Prettier and env variable setting for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/expect.js": "^0.3.29",
         "@types/mocha": "^8.2.1",
         "@types/node": "^18.15.11",
+        "cross-env": "7.0.3",
         "expect.js": "0.3.1",
         "ioredis": "^5.3.2",
         "mocha": "^10.1.0",
@@ -818,6 +819,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3601,6 +3620,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
     "prepack": "npm run compile",
     "test": "npm run format:check && npm run compile && npm run test:redis-standalone && npm run test:redis-cluster && npm run test:ioredis-standalone && npm run test:ioredis-cluster",
     "test:redis-standalone": "nyc mocha --require ts-node/register test/**/*.ts",
-    "test:redis-cluster": "REDIS_CLUSTER=1 mocha --require ts-node/register test/**/*.ts",
-    "test:ioredis-standalone": "REDIS_LIB=ioredis mocha --require ts-node/register test/**/*.ts",
-    "test:ioredis-cluster": "REDIS_LIB=ioredis REDIS_CLUSTER=1 mocha --require ts-node/register test/**/*.ts"
+    "test:redis-cluster": "cross-env REDIS_CLUSTER=1 mocha --require ts-node/register test/**/*.ts",
+    "test:ioredis-standalone": "cross-env REDIS_LIB=ioredis mocha --require ts-node/register test/**/*.ts",
+    "test:ioredis-cluster": "cross-env REDIS_LIB=ioredis REDIS_CLUSTER=1 mocha --require ts-node/register test/**/*.ts"
+  },
+  "prettier": {
+    "endOfLine": "auto"
   },
   "dependencies": {
     "@msgpack/msgpack": "~2.8.0",
@@ -34,6 +37,7 @@
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^8.2.1",
     "@types/node": "^18.15.11",
+    "cross-env": "7.0.3",
     "expect.js": "0.3.1",
     "ioredis": "^5.3.2",
     "mocha": "^10.1.0",


### PR DESCRIPTION
Changes:

- using cross-env to set env variables across platforms
- set Prettier options "endOfLine": "auto" to make sure that EOL is treated correctly 

I reverted some previous change on redis-cluster configuration, because I'm not sure that setting "IP=0.0.0.0" env variable is safe for everyone.
Currently, my tests on Windows 10 don't work without that setting, but I don't want to risk to break others' work just because it's not working for me.