### PR TITLE
chore: cleanup imports and use exported type and enum from socket.io-adapter

### DIFF
--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -1,10 +1,11 @@
-import {
-  ClusterAdapterWithHeartbeat,
-  type ClusterMessage,
-  type PrivateSessionId,
-  type Session,
-  type ServerId,
-  type ClusterResponse,
+import { ClusterAdapterWithHeartbeat } from "socket.io-adapter";
+import type {
+  ClusterAdapterOptions,
+  ClusterMessage,
+  PrivateSessionId,
+  Session,
+  ServerId,
+  ClusterResponse,
 } from "socket.io-adapter";
 import { decode, encode } from "@msgpack/msgpack";
 import debugModule from "debug";
@@ -13,20 +14,6 @@ import { hasBinary, XADD, XREAD } from "./util";
 const debug = debugModule("socket.io-redis-streams-adapter");
 
 const RESTORE_SESSION_MAX_XRANGE_CALLS = 100;
-
-// TODO ClusterAdapterOptions should be exported by the socket.io-adapter package
-interface ClusterAdapterOptions {
-  /**
-   * The number of ms between two heartbeats.
-   * @default 5_000
-   */
-  heartbeatInterval?: number;
-  /**
-   * The number of ms without heartbeat before we consider a node down.
-   * @default 10_000
-   */
-  heartbeatTimeout?: number;
-}
 
 export interface RedisStreamsAdapterOptions {
   /**

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -1,4 +1,4 @@
-import { ClusterAdapterWithHeartbeat } from "socket.io-adapter";
+import { ClusterAdapterWithHeartbeat, MessageType } from "socket.io-adapter";
 import type {
   ClusterAdapterOptions,
   ClusterMessage,
@@ -177,11 +177,11 @@ class RedisStreamsAdapter extends ClusterAdapterWithHeartbeat {
     if (message.data) {
       // TODO MessageType should be exported by the socket.io-adapter package
       const mayContainBinary = [
-        3, // MessageType.BROADCAST,
-        8, // MessageType.FETCH_SOCKETS_RESPONSE,
-        9, // MessageType.SERVER_SIDE_EMIT,
-        10, // MessageType.SERVER_SIDE_EMIT_RESPONSE,
-        12, // MessageType.BROADCAST_ACK,
+        MessageType.BROADCAST,
+        MessageType.FETCH_SOCKETS_RESPONSE,
+        MessageType.SERVER_SIDE_EMIT,
+        MessageType.SERVER_SIDE_EMIT_RESPONSE,
+        MessageType.BROADCAST_ACK,
       ].includes(message.type);
 
       // @ts-ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@socket.io/redis-streams-adapter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@socket.io/redis-streams-adapter",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "~2.8.0",
@@ -32,7 +32,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "socket.io-adapter": "^2.5.2"
+        "socket.io-adapter": "^2.5.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2455,9 +2455,9 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.3.tgz",
-      "integrity": "sha512-OtkQtynXUM0JSEwmI6YlEJ5hU9kpDUVjda0hx8QVffKhqum53xhynH8eTCyjHSfI8FiJnyfK8I3Dlc88Jr81Dg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
+      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.11.0"
@@ -4833,9 +4833,9 @@
       }
     },
     "socket.io-adapter": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.3.tgz",
-      "integrity": "sha512-OtkQtynXUM0JSEwmI6YlEJ5hU9kpDUVjda0hx8QVffKhqum53xhynH8eTCyjHSfI8FiJnyfK8I3Dlc88Jr81Dg==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
+      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
       "requires": {
         "debug": "~4.3.4",
         "ws": "~8.11.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "~4.3.1"
   },
   "peerDependencies": {
-    "socket.io-adapter": "^2.5.3"
+    "socket.io-adapter": "^2.5.4"
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",


### PR DESCRIPTION
- split type and other imports to be consistent with other adapter repos
- use the `MessageType` enum instead of just hardcoded numbers