### PR TITLE
Update persistSession override

### DIFF
--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -234,14 +234,15 @@ class RedisStreamsAdapter extends ClusterAdapterWithHeartbeat {
     debug("persisting session %o", session);
     const sessionKey = this.#opts.sessionKeyPrefix + session.pid;
     const encodedSession = Buffer.from(encode(session)).toString("base64");
+    const maxDisconnectionDuration = this.nsp.server.opts.connectionStateRecovery.maxDisconnectionDuration.toString();
 
     SET(
       this.#redisClient,
       sessionKey,
       encodedSession,
-      this.nsp.server.opts.connectionStateRecovery.maxDisconnectionDuration
+      maxDisconnectionDuration
     );
-  }
+}
 
   override async restoreSession(
     pid: PrivateSessionId,


### PR DESCRIPTION
Make sure the maxDisconnectDuration is a string to avoid using an object in Redis SET() as this will throw an error.
This should address https://github.com/socketio/socket.io-redis-streams-adapter/issues/17 based on my testing.