### PR TITLE
Modify missedPackets to include entry ID

### DIFF
--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -289,14 +289,14 @@ class RedisStreamsAdapter extends ClusterAdapterWithHeartbeat {
 
       for (const entry of entries) {
         if (entry.message.nsp === this.nsp.name && entry.message.type === "3") {
-          const message = RedisStreamsAdapter.decode(entry.message);
+          const message = RedisStreamsAdapter.decode(entry.message) as {
+            data: any;
+          };
+          const { packet, opts } = message.data;
 
-          // @ts-ignore
-          if (shouldIncludePacket(session.rooms, message.data.opts)) {
-            const packetData = message.data.packet.data.slice();
-            packetData.push(entry.id);
-            // @ts-ignore
-            session.missedPackets.push(packetData);
+          if (shouldIncludePacket(session.rooms, opts)) {
+            packet.data.push(entry.id);
+            session.missedPackets.push(packet.data);
           }
         }
         offset = entry.id;


### PR DESCRIPTION
restore messages contain actual entry ID to correct client offset

https://github.com/socketio/socket.io-redis-streams-adapter/issues/39
https://github.com/socketio/socket.io/issues/5419