### PR TITLE
fix(csr): bound XRANGE reads during session recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ io.listen(3000);
 | `channelPrefix`     | The prefix of the Redis PUB/SUB channels used to communicate between the nodes.                                       | `socket.io`    |
 | `useShardedPubSub`  | Whether to use sharded PUB/SUB (added in Redis 7.0) to communicate between the nodes.                                 | `false`        |
 | `maxLen`            | The maximum size of the stream. Almost exact trimming (~) is used.                                                    | `10_000`       |
-| `readCount`         | The number of elements to fetch per XREAD call.                                                                       | `100`          |
+| `readCount`         | The number of elements to fetch per XREAD call (polling) and per XRANGE call (session recovery).                      | `100`          |
 | `blockTimeInMs`     | The number of ms before the XREAD call times out.                                                                     | `5_000`        |
 | `sessionKeyPrefix`  | The prefix of the key used to store the Socket.IO session, when the connection state recovery feature is enabled.     | `sio:session:` |
 | `onlyPlaintext`     | Whether the transmitted data contains only JSON-serializable objects without binary data (Buffer, ArrayBuffer, etc.). | `false`        |

--- a/lib/adapter.ts
+++ b/lib/adapter.ts
@@ -27,7 +27,7 @@ import {
 
 const debug = debugModule("socket.io-redis-streams-adapter");
 
-const RESTORE_SESSION_MAX_XRANGE_CALLS = 100;
+const RESTORE_SESSION_EXTRA_XRANGE_CALLS = 100;
 
 export interface RedisStreamsAdapterOptions {
   /**
@@ -64,7 +64,8 @@ export interface RedisStreamsAdapterOptions {
    */
   maxLen?: number;
   /**
-   * The number of elements to fetch per XREAD call.
+   * The number of elements to fetch per XREAD call (polling) and per XRANGE
+   * call (session recovery).
    * @default 100
    */
   readCount?: number;
@@ -196,6 +197,14 @@ export function createAdapter(
     },
     opts
   );
+
+  if (!Number.isInteger(options.readCount) || options.readCount <= 0) {
+    throw new Error("readCount must be a positive integer");
+  }
+
+  if (!Number.isInteger(options.maxLen) || options.maxLen <= 0) {
+    throw new Error("maxLen must be a positive integer");
+  }
 
   function onMessage(message: RawClusterMessage, offset: string) {
     namespaceToAdapters.get(message.nsp)?.onRawMessage(message, offset);
@@ -464,14 +473,19 @@ class RedisStreamsAdapter extends ClusterAdapter {
 
     session.missedPackets = [];
 
-    // FIXME we need to add an arbitrary limit here, because if entries are added faster than what we can consume, then
-    // we will loop endlessly. But if we stop before reaching the end of the stream, we might lose messages.
-    for (let i = 0; i < RESTORE_SESSION_MAX_XRANGE_CALLS; i++) {
+    // Limit iterations to prevent infinite loops when entries are added faster
+    // than we can consume, while keeping the previous 100-call headroom.
+    const maxXrangeCalls =
+      Math.ceil(this.#opts.maxLen / this.#opts.readCount) +
+      RESTORE_SESSION_EXTRA_XRANGE_CALLS;
+
+    for (let i = 0; i < maxXrangeCalls; i++) {
       const entries = await XRANGE(
         this.#redisClient,
         this.#streamName,
         RedisStreamsAdapter.nextOffset(offset),
-        "+"
+        "+",
+        this.#opts.readCount
       );
 
       if (entries.length === 0) {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -151,11 +151,20 @@ export function XRANGE(
   redisClient: any,
   streamName: string,
   start: string,
-  end: string
+  end: string,
+  count?: number
 ) {
   if (isRedisV4Client(redisClient)) {
-    return redisClient.xRange(streamName, start, end);
+    const options = count !== undefined ? { COUNT: count } : undefined;
+    return redisClient.xRange(streamName, start, end, options);
   } else {
+    if (count !== undefined) {
+      return redisClient
+        .xrange(streamName, start, end, "COUNT", count)
+        .then((res) => {
+          return res.map(mapResult);
+        });
+    }
     return redisClient.xrange(streamName, start, end).then((res) => {
       return res.map(mapResult);
     });


### PR DESCRIPTION
## Summary

This updates `restoreSession()` to read missed stream entries with bounded `XRANGE ... COUNT` batches instead of issuing one unbounded `XRANGE offset +` request.

## Why

The previous restore path could request the entire remainder of the Redis stream in one command. If the stream contained many large entries, Redis could build a very large normal client output buffer for that single response. In constrained Redis/Valkey environments, that can contribute to OOM risk or cause the client connection to be closed by output-buffer limits, after which clients such as ioredis may retry the same problematic command.

## Changes

- Adds optional `COUNT` support to the shared `XRANGE()` helper for both `node-redis` and `ioredis`.
- Uses `readCount` as the `XRANGE COUNT` batch size during session recovery.
- Iterates until there are no more entries to restore or a bounded loop limit is reached.
- Sets the loop limit from the configured stream retention and batch size, plus the previous 100-call safety headroom:
  - `ceil(maxLen / readCount) + 100`
- Validates `readCount` and `maxLen` as positive integers so the bounded restore path cannot silently fall back to invalid command parameters.
- Updates the README option description to clarify that `readCount` applies to both `XREAD` polling and `XRANGE` session recovery.

## Compatibility

This keeps the existing Redis Streams based recovery model intact and does not require a new Redis client API. The adapter still routes through the existing `XRANGE()` helper, with command shapes for both supported client families.

## Testing

- `npm run format:check`
- `npm run compile`

`npm test` was not completed in my local environment because the Redis integration tests require local Redis/cluster connections that were unavailable there.